### PR TITLE
Resolving issue with Actionview template error

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,4 +5,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( banner.css dradis3.js dradis3.css )
+Rails.application.config.assets.precompile += %w( banner.css dradis3.js dradis3.css OpenSans-Regular.eot OpenSans-Regular.woff OpenSans-Regular.ttf OpenSans-Regular.svg jquery.textile.loading.gif )


### PR DESCRIPTION
Received multiple of the below error when accessing the app for the first time:

`ActionView::Template::Error (Asset filtered out and will not be served: add `Rails.application.config.assets.precompile += %w( jquery.textile.loading.gif )` to `config/initializers/assets.rb` and restart your server`

Added the above (and references to OpenSans) to the assets.rb