### PR TITLE
Remove local flag from bundle install

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -44,7 +44,7 @@ Dir.chdir APP_ROOT do
 
   puts "== Installing dependencies =="
   system "gem install bundler --conservative"
-  system "bundle check || bundle install --local"
+  system "bundle check || bundle install"
 
   puts "\n== Preparing database =="
   # Rails 4.2


### PR DESCRIPTION
the bundle install command had the --local switch added, meaning that it would not connect to rubygems to try and install gems.  As some of the gems are not in the vendor/cache it was failing, causing problems with the install.  

So unless there's a specific reason to retain --local, this change suggests removing it.